### PR TITLE
v.19.2.5 - Switch to official alpine docker baseimage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,4 +36,4 @@ ENV VERSION=""
 ENV DELAY=""
 
 # Run command
-ENTRYPOINT ["feedcrawler", "--docker", "--log-level", "$LOGLEVEL", "--jd-user", "$USER", "--jd-pass", "$PASS", "--jd-device", "$DEVICE", "--delay", "$DELAY"]
+ENTRYPOINT ["sh", "-c", "feedcrawler --docker --log-level=$LOGLEVEL --jd-user=$USER --jd-pass=$PASS --jd-device=$DEVICE --delay=$DELAY"]

--- a/feedcrawler/providers/version.py
+++ b/feedcrawler/providers/version.py
@@ -9,7 +9,7 @@ from urllib.request import urlopen
 
 
 def get_version():
-    return "19.2.4"
+    return "19.2.5"
 
 
 def create_version_file():

--- a/feedcrawler/web_interface/vuejs_frontend/package-lock.json
+++ b/feedcrawler/web_interface/vuejs_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedcrawler-web",
-  "version": "19.2.4",
+  "version": "19.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedcrawler-web",
-      "version": "19.2.4",
+      "version": "19.2.5",
       "dependencies": {
         "@formkit/i18n": "^1.6.5",
         "@formkit/vue": "^1.6.5",

--- a/feedcrawler/web_interface/vuejs_frontend/package.json
+++ b/feedcrawler/web_interface/vuejs_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedcrawler-web",
-  "version": "19.2.4",
+  "version": "19.2.5",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
- linuxserver baseimage messed up multiple times
- less clutter in the setup
- removed automatic baseimage builds to stay reproducable