### PR TITLE
fix the for loop for direct connection check

### DIFF
--- a/feedcrawler/external_tools/myjd_api.py
+++ b/feedcrawler/external_tools/myjd_api.py
@@ -839,7 +839,7 @@ class Jddevice:
                 return response['data']
         else:
             # Direct connection info available, we try to use it.
-            for conn in self.__direct_connection_info:
+            for conn in self.__direct_connection_info[:]:
                 connection_ip = conn['conn']['ip']
                 # prevent connection to internal docker ip
                 if time.time() > conn['cooldown']:
@@ -863,6 +863,7 @@ class Jddevice:
                         conn['cooldown'] = time.time() + 3600
                         self.__direct_connection_info.remove(conn)
                         self.__direct_connection_info.append(conn)
+            
             # None of the direct connections worked, we set a cooldown for direct connections
             self.__direct_connection_consecutive_failures += 1
             self.__direct_connection_cooldown = time.time() + (60 * self.__direct_connection_consecutive_failures)


### PR DESCRIPTION
Mittels des [:] wird eine Duplikat der liste in dem Klassen Objekt verwendet in welchem iteriert wird. Dadurch werden alle Elemente iteriert. Bei dem bisherigen Verfahren wurde der Pointer mit verschoben, weshalb der Loop vorzeitig abgebrochen wurde.