### PR TITLE
SF Bugfix: Improve download link fallback handling

### DIFF
--- a/feedcrawler/providers/version.py
+++ b/feedcrawler/providers/version.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 
 
 def get_version():
-    return "21.0.3"
+    return "21.0.4"
 
 
 def create_version_file():

--- a/feedcrawler/web_interface/vuejs_frontend/package-lock.json
+++ b/feedcrawler/web_interface/vuejs_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feedcrawler-web",
-  "version": "21.0.3",
+  "version": "21.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feedcrawler-web",
-      "version": "21.0.3",
+      "version": "21.0.4",
       "dependencies": {
         "@formkit/i18n": "^1.6.9",
         "@formkit/vue": "^1.6.9",

--- a/feedcrawler/web_interface/vuejs_frontend/package.json
+++ b/feedcrawler/web_interface/vuejs_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feedcrawler-web",
-  "version": "21.0.3",
+  "version": "21.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Modified the logic to better handle missing or incorrect hoster labels by introducing a fallback mechanism. Now, if no valid hoster is found, the first link is used as a fallback, with appropriate logs for easier debugging. Errors or missing links without fallback are also logged for better traceability.